### PR TITLE
Fixing a venders → vendors typo

### DIFF
--- a/debian/lib32mali-rk-utgard-2th-r7p0.install
+++ b/debian/lib32mali-rk-utgard-2th-r7p0.install
@@ -1,3 +1,3 @@
 #! /usr/bin/dh-exec
 usr/lib/${DEB_HOST_MULTIARCH}/libmali-utgard-2th-r7p0.so => usr/lib/${DEB_HOST_MULTIARCH}/libMali.so
-etc/OpenCL/vendors/mali.icd  /etc/OpenCL/venders
+etc/OpenCL/vendors/mali.icd  /etc/OpenCL/vendors


### PR DESCRIPTION
Also did a grep -i venders * just to be sure.

This should fix https://github.com/rockchip-linux/libmali/issues/5

Signed-off-by: Myy <myy@miouyouyou.fr>